### PR TITLE
Add option to control verify connection on start

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -47,7 +47,7 @@ func newConn(conf connConfig, muted bool) (*conn, error) {
 	}
 	// When using UDP do a quick check to see if something is listening on the
 	// given port to return an error as soon as possible.
-	if c.network[:3] == "udp" {
+	if conf.VerifyConnection && c.network[:3] == "udp" {
 		for i := 0; i < 2; i++ {
 			_, err = c.w.Write(nil)
 			if err != nil {

--- a/options.go
+++ b/options.go
@@ -19,12 +19,13 @@ type clientConfig struct {
 }
 
 type connConfig struct {
-	Addr          string
-	ErrorHandler  func(error)
-	FlushPeriod   time.Duration
-	MaxPacketSize int
-	Network       string
-	TagFormat     TagFormat
+	Addr             string
+	ErrorHandler     func(error)
+	FlushPeriod      time.Duration
+	MaxPacketSize    int
+	Network          string
+	TagFormat        TagFormat
+	VerifyConnection bool
 }
 
 // An Option represents an option for a Client. It must be used as an
@@ -120,6 +121,13 @@ type TagFormat uint8
 func TagsFormat(tf TagFormat) Option {
 	return Option(func(c *config) {
 		c.Conn.TagFormat = tf
+	})
+}
+
+// Whether to verify the connection on creation
+func VerifyConnection(shouldVerify bool) Option {
+	return Option(func(c *config) {
+		c.Conn.VerifyConnection = shouldVerify
 	})
 }
 

--- a/statsd.go
+++ b/statsd.go
@@ -23,8 +23,9 @@ func New(opts ...Option) (*Client, error) {
 			FlushPeriod: 100 * time.Millisecond,
 			// Worst-case scenario:
 			// Ethernet MTU - IPv6 Header - TCP Header = 1500 - 40 - 20 = 1440
-			MaxPacketSize: 1440,
-			Network:       "udp",
+			MaxPacketSize:    1440,
+			Network:          "udp",
+			VerifyConnection: true,
 		},
 	}
 	for _, o := range opts {


### PR DESCRIPTION
## what

Add option to control if the connection is verified when created
## why

Requiring an active listener at startup is problematic. The listening service may not have come up yet, or may be restarting preventing this service from launching
