### PR TITLE
Support duration submission in go statsd

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"gopkg.in/alexcesaro/statsd.v2"
+	"github.com/sagansystems/statsd-go"
 )
 
 var (

--- a/statsd.go
+++ b/statsd.go
@@ -106,7 +106,7 @@ func (c *Client) Timing(bucket string, value interface{}) {
 	if c.skip() {
 		return
 	}
-	c.conn.metric(c.prefix, bucket, value, "ms", c.rate, c.tags)
+	c.conn.metric(c.prefix, bucket, timingToNumber(value), "ms", c.rate, c.tags)
 }
 
 // Histogram sends an histogram value to a bucket.
@@ -167,4 +167,15 @@ func (c *Client) Close() {
 	c.conn.handleError(c.conn.w.Close())
 	c.conn.closed = true
 	c.conn.mu.Unlock()
+}
+
+func timingToNumber(value interface{}) interface{} {
+	switch v := value.(type) {
+	case time.Duration:
+		return v.Milliseconds()
+	case *time.Duration:
+		return v.Milliseconds()
+	default:
+		return value
+	}
 }

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -43,6 +43,19 @@ func TestTiming(t *testing.T) {
 	})
 }
 
+func TestTimingWithDuration(t *testing.T) {
+	testOutput(t, "test_key:6|ms", func(c *Client) {
+		c.Timing(testKey, time.Duration(6000000))
+	})
+}
+
+func TestTimingWithDurationP(t *testing.T) {
+	d := time.Duration(6000000)
+	testOutput(t, "test_key:6|ms", func(c *Client) {
+		c.Timing(testKey, &d)
+	})
+}
+
 func TestHistogram(t *testing.T) {
 	testOutput(t, "test_key:17|h", func(c *Client) {
 		c.Histogram(testKey, 17)


### PR DESCRIPTION
**What**
- When a `time.Duration` or `*time.Duration` is passed, convert it to milliseconds (`int64`) so that it can be handled by the client

**Why**
In `go` we often measure time as a `time.Duration` so it make sense for the package to handle this internally without requiring the application to do the conversion

**Testing**
Unit tests cover this pretty well